### PR TITLE
Fix/sync blocks wrong from slot when the broadcast too fast

### DIFF
--- a/logx/logx.go
+++ b/logx/logx.go
@@ -16,36 +16,28 @@ const (
 
 var logger = log.New(os.Stdout, "", log.LstdFlags)
 
-func genericLog(color string, level string, category string, content ...interface{}) {
-	var message string
-	if len(content) > 1 {
-		if format, ok := content[0].(string); ok {
-			message = fmt.Sprintf(format, content[1:]...)
-		} else {
-			message = fmt.Sprint(content...)
-		}
-	} else {
-		message = fmt.Sprint(content...)
-	}
-
-	coloredCategory := fmt.Sprintf("%s[%s][%s]%s", color, level, category, ColorReset)
+func Info(category string, content ...interface{}) {
+	message := fmt.Sprint(content...)
+	coloredCategory := fmt.Sprintf("%s[%s]%s", ColorGreen, category, ColorReset)
 	logger.Printf("%s: %s", coloredCategory, message)
 }
 
-func Info(category string, content ...interface{}) {
-	genericLog(ColorGreen, "INFO", category, content...)
-}
-
 func Error(category string, content ...interface{}) {
-	genericLog(ColorRed, "ERROR", category, content...)
+	message := fmt.Sprint(content...)
+	coloredCategory := fmt.Sprintf("%s[ERROR][%s]%s", ColorRed, category, ColorReset)
+	logger.Printf("%s: %s", coloredCategory, message)
 }
 
 func Warn(category string, content ...interface{}) {
-	genericLog(ColorYellow, "WARN", category, content...)
+	message := fmt.Sprint(content...)
+	coloredCategory := fmt.Sprintf("%s[WARN][%s]%s", ColorYellow, category, ColorReset)
+	logger.Printf("%s: %s", coloredCategory, message)
 }
 
 func Debug(category string, content ...interface{}) {
-	genericLog(ColorBlue, "DEBUG", category, content...)
+	message := fmt.Sprint(content...)
+	coloredCategory := fmt.Sprintf("%s[DEBUG][%s]%s", ColorBlue, category, ColorReset)
+	logger.Printf("%s: %s", coloredCategory, message)
 }
 
 // Errorf logs an error message and returns a formatted error

--- a/p2p/block.go
+++ b/p2p/block.go
@@ -78,10 +78,6 @@ func (ln *Libp2pNetwork) handleBlockSyncRequestTopic(ctx context.Context, sub *p
 				continue
 			}
 
-			if req.FromSlot == 0 {
-				continue
-			}
-
 			// Skip requests from self
 			if msg.ReceivedFrom == ln.host.ID() {
 				continue

--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -89,10 +89,6 @@ func (ln *Libp2pNetwork) RequestLatestSlotFromPeers(ctx context.Context) (uint64
 }
 
 func (ln *Libp2pNetwork) RequestBlockSync(ctx context.Context, fromSlot uint64) error {
-	if fromSlot == 0 {
-		return nil
-	}
-
 	toSlot := fromSlot + BatchSize - 1
 
 	requestID := GenerateSyncRequestID()

--- a/p2p/pubsub.go
+++ b/p2p/pubsub.go
@@ -386,14 +386,8 @@ func (ln *Libp2pNetwork) startInitialSync(bs blockstore.Store) {
 	if _, err := ln.RequestLatestSlotFromPeers(ctx); err != nil {
 		logx.Warn("NETWORK:SYNC BLOCK", "Failed to request latest slot from peers:", err)
 	}
-
-	var fromSlot uint64 = 0
-	localLatestSlot := bs.GetLatestSlot()
-	if localLatestSlot > 0 {
-		fromSlot = localLatestSlot + 1
-	}
-
-	if err := ln.RequestBlockSync(ctx, fromSlot); err != nil {
+	// sync from 0
+	if err := ln.RequestBlockSync(ctx, 0); err != nil {
 		logx.Error("NETWORK:SYNC BLOCK", "Failed to send initial sync request: %v", err)
 	}
 }


### PR DESCRIPTION
When broadcasting runs too fast, a new node’s latest slot may incorrectly match the old node’s latest slot, which causes block synchronization errors.
To avoid this, the node should always synchronize from slot 0 to ensure consistency, even if it means ignoring cases of missing data caused by invalid blocks.