### PR TITLE
Mmn 341 validate requests

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mezonai/mmn/errors"
 	"github.com/mezonai/mmn/exception"
 	"github.com/mezonai/mmn/monitoring"
+	"github.com/mezonai/mmn/security/validation"
 	"github.com/mezonai/mmn/zkverify"
 
 	"github.com/holiman/uint256"
@@ -191,10 +192,10 @@ func (mp *Mempool) cheapValidateTransaction(tx *transaction.Transaction) error {
 		return errors.NewError(errors.ErrCodeInvalidAmount, errors.ErrMsgInvalidAmount)
 	}
 
-	// Validate memo length (max 64 characters)
-	if len(tx.TextData) > MAX_MEMO_CHARACTERS {
+	// Validate memo length using centralized limit
+	if len(tx.TextData) > validation.ValidationMaxTextDataLen {
 		monitoring.RecordRejectedTx(monitoring.TxRejectedUnknown)
-		return fmt.Errorf("memo too long: max %d chars, got %d", MAX_MEMO_CHARACTERS, len(tx.TextData))
+		return fmt.Errorf("memo too long: max %d chars, got %d", validation.ValidationMaxTextDataLen, len(tx.TextData))
 	}
 
 	// Validate mempool size

--- a/network/constants.go
+++ b/network/constants.go
@@ -5,9 +5,4 @@ import "time"
 const (
 	// This prevents hung requests.
 	GRPCDefaultDeadline = 60 * time.Second
-
-	// The maximum inbound gRPC message size (bytes)
-	GRPCMaxRecvMsgSize = 4 * 1024 * 1024
-	// The maximum outbound gRPC message size (bytes)
-	GRPCMaxSendMsgSize = 20 * 1024 * 1024
 )

--- a/security/validation/constants.go
+++ b/security/validation/constants.go
@@ -1,0 +1,17 @@
+package validation
+
+const (
+	ValidationMaxTextDataLen  = 512
+	ValidationMaxAmountLen    = 128
+	ValidationMaxSignatureLen = 2048
+	ValidationMaxTxHashLen    = 128
+	ValidationMaxBlockRange   = 500
+	ValidationMaxExtraInfoLen = 2048
+
+	MaxBodyBytes     = 4 * 1024 * 1024
+	MaxResponseBytes = 20 * 1024 * 1024
+)
+
+var InjectionPatterns = []string{
+	"${{", "{{", "}}", "`", "$(", "|", "||", "&&", ">", "<script", "onerror=", "${jndi:", "..", "%0a", "%0d",
+}


### PR DESCRIPTION
#341 
- Addresses: Base58 strict (decodes and ≥ 32 bytes).
- amount: required, length ≤ 128 (uint256 string).
- text_data: length ≤ 512 and matches regex.
- extra_info: length ≤ 2048.
- signature: required, length ≤ 2048.
- tx_hash: length ≤ 128.
- tag : only latest | pending.
- Injection pattern detection
- safe-character regex; length capped
------------------------------------------
- JSON-RPC: require Content-Type application/json.
- JSON-RPC: reject unknown fields.
- JSON-RPC: Body 4MB, Response 20MB.
- gRPC: MaxRecv 4MB, MaxSend 20MB.